### PR TITLE
Html tag support

### DIFF
--- a/src/sweet-alert-vuetify.vue
+++ b/src/sweet-alert-vuetify.vue
@@ -67,14 +67,14 @@
           <v-card-title class="justify-center" v-if="configTitle.visible">
             <div v-if="!showLoading">
               <slot name="title">
-                <p v-bind="configTitle.style">{{ configTitle.text }}</p>
+                <p v-bind="configTitle.style" v-html="configTitle.text"></p>
               </slot>
             </div>
             <div v-if="showLoading">{{ configLoading.text }}</div>
           </v-card-title>
           <v-card-text class="text-center">
             <slot name="content">
-              <p class="body-2" style="word-break:normal;" v-if="getSubtitle !== ''">{{ getSubtitle }}</p>
+              <p class="body-2" style="word-break:normal;" v-if="getSubtitle !== ''" v-html="getSubtitle"></p>
             </slot>
           </v-card-text>
           <v-card-actions class="mb-4" v-if="!showLoading">


### PR DESCRIPTION
Using v-html to add html tag support on title and subtitle. 
**Warning:** sweet-alert library is not sanitized and v-html is the same, It is the developer's responsibility to escape any user input when using this library, so XSS attacks would be prevented.